### PR TITLE
fix parameter error in logger.set_contruction_data_and_log : missing …

### DIFF
--- a/oslo/torch/nn/parallel/data_parallel/distributed_data_parallel.py
+++ b/oslo/torch/nn/parallel/data_parallel/distributed_data_parallel.py
@@ -729,7 +729,7 @@ class _DistributedDataParallel(Module, Joinable):
             -1 if self.output_device is None else self.output_device,
             self.broadcast_buffers,
             has_sync_bn,
-            self.static_graph
+            self.static_graph,
         )
 
         # passing a handle to torch.nn.SyncBatchNorm layer

--- a/oslo/torch/nn/parallel/data_parallel/distributed_data_parallel.py
+++ b/oslo/torch/nn/parallel/data_parallel/distributed_data_parallel.py
@@ -729,6 +729,7 @@ class _DistributedDataParallel(Module, Joinable):
             -1 if self.output_device is None else self.output_device,
             self.broadcast_buffers,
             has_sync_bn,
+            self.static_graph
         )
 
         # passing a handle to torch.nn.SyncBatchNorm layer


### PR DESCRIPTION
…static_graph param

## Title 

- Fix the parameter error in set_construction_data_and_log 

## Description

Current code has an error when set_construction_data_and_log error message is called.
 TypeError: set_construction_data_and_log(): incompatible function arguments. The following argument types are supported:
    1. (self: torch._C._distributed_c10d.Logger, module_name: str, device_ids: List[int], output_device: int, broadcast_buffers: bool, has_sync_bn: bool, static_graph: bool) -> None

By adding static_graph to the function, the error is resolved.
(https://github.com/pytorch/pytorch/blob/master/torch/nn/parallel/distributed.py#L762)

## Linked Issues

- resolved #00
