### PR TITLE
comment out unnecessary initialized import

### DIFF
--- a/oslo/transformers/__init__.py
+++ b/oslo/transformers/__init__.py
@@ -1,10 +1,10 @@
-from oslo.transformers.models.gpt2.modeling_gpt2 import (
-    GPT2Model,
-    GPT2LMHeadModel,
-    GPT2DoubleHeadsModel,
-    GPT2ForSequenceClassification,
-    GPT2ForTokenClassification,
-)
+# from oslo.transformers.models.gpt2.modeling_gpt2 import (
+#     GPT2Model,
+#     GPT2LMHeadModel,
+#     GPT2DoubleHeadsModel,
+#     GPT2ForSequenceClassification,
+#     GPT2ForTokenClassification,
+# )
 
 
 from oslo.transformers.training_args import TrainingArguments


### PR DESCRIPTION
## Title

Comment out unnecessary init GPT2 models in transformers

## Description

It import GPT2Model even thought not using GPT2Model

## Linked Issues

- resolved #00
