### PR TITLE
fix: restore some import functions

### DIFF
--- a/oslo/torch/nn/__init__.py
+++ b/oslo/torch/nn/__init__.py
@@ -13,6 +13,19 @@ from oslo.torch.nn.modules.embedding import (
     VocabParallelEmbedding3D,
 )
 from oslo.torch.nn.modules.functional import _NGramRepeatBlockFunction
+from oslo.torch.nn.modules.functional import (
+    fused_bias_dropout,
+    fused_bias_gelu,
+    fused_gelu,
+    multi_head_attention_forward,
+    fused_scale_mask_softmax,
+    fused_rms_norm_affine,
+    fused_layer_norm,
+    mixed_dtype_fused_layer_norm_affine,
+    fused_layer_norm_affine,
+    mixed_dtype_fused_rms_norm_affine,
+    fused_rms_norm,
+)
 from oslo.torch.nn.modules.layer_norm import (
     LayerNorm1D,
     LayerNorm2D,

--- a/oslo/torch/nn/__init__.py
+++ b/oslo/torch/nn/__init__.py
@@ -17,7 +17,6 @@ from oslo.torch.nn.modules.functional import (
     fused_bias_dropout,
     fused_bias_gelu,
     fused_gelu,
-    multi_head_attention_forward,
     fused_scale_mask_softmax,
     fused_rms_norm_affine,
     fused_layer_norm,


### PR DESCRIPTION
restore from clean-up commit except multi_head_attention_forward

Closes #43

## Title

-restore some functions 

## Description

- include fused_bias_gelu function

## Linked Issues

- resolved #43
