### PR TITLE
[#62] feat: Use fused_scale_mask_softmax functionality on GPT2

### DIFF
--- a/oslo/torch/nn/modules/functional.py
+++ b/oslo/torch/nn/modules/functional.py
@@ -350,6 +350,7 @@ def _fused_scale_mask_softmax_sanity_check(input, scale, softmax_in_fp32):
     assert scale is not None, "scale must not be None."
     # assert scale == 1.0 or softmax_in_fp32, "softmax should be in fp32 when scaled"
 
+
 def _is_fused_scale_mask_softmax_available(
     input, scale, softmax_in_fp32, use_triang_mask
 ):

--- a/oslo/torch/nn/modules/functional.py
+++ b/oslo/torch/nn/modules/functional.py
@@ -348,8 +348,7 @@ def fused_bias_dropout(x, bias, p, training, inplace):
 def _fused_scale_mask_softmax_sanity_check(input, scale, softmax_in_fp32):
     assert input.dim() == 4, "input must be be `(batch, nhead, len_q, len_k)`."
     assert scale is not None, "scale must not be None."
-    assert scale == 1.0 or softmax_in_fp32, "softmax should be in fp32 when scaled"
-
+    # assert scale == 1.0 or softmax_in_fp32, "softmax should be in fp32 when scaled"
 
 def _is_fused_scale_mask_softmax_available(
     input, scale, softmax_in_fp32, use_triang_mask
@@ -357,6 +356,9 @@ def _is_fused_scale_mask_softmax_available(
     bsz, np, sq, sk = input.size()
     dtype = input.dtype
     _fused_scale_mask_softmax_sanity_check(input, scale, softmax_in_fp32)
+
+    if not (scale == 1.0 or softmax_in_fp32):
+        return False
 
     if dtype != torch.float16 and dtype != torch.bfloat16:
         return False

--- a/oslo/transformers/models/gpt2/configuration_gpt2.py
+++ b/oslo/transformers/models/gpt2/configuration_gpt2.py
@@ -151,6 +151,7 @@ class GPT2Config(PretrainedConfig):
         eos_token_id=50256,
         scale_attn_by_inverse_layer_idx=False,
         reorder_and_upcast_attn=False,
+        softmax_in_fp32=True,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -177,6 +178,8 @@ class GPT2Config(PretrainedConfig):
 
         self.bos_token_id = bos_token_id
         self.eos_token_id = eos_token_id
+
+        self.softmax_in_fp32 = softmax_in_fp32
 
         super().__init__(bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
 

--- a/oslo/transformers/models/gpt2/modeling_gpt2.py
+++ b/oslo/transformers/models/gpt2/modeling_gpt2.py
@@ -136,7 +136,7 @@ class GPT2Attention(nn.Module):
         self.resid_dropout = onn.FusedBiasDropout(config.resid_pdrop)
 
         self.pruned_heads = set()
-        if not hasattr(config, 'softmax_in_fp32'): 
+        if not hasattr(config, "softmax_in_fp32"):
             self.softmax_in_fp32 = True
         else:
             self.softmax_in_fp32 = config.softmax_in_fp32

--- a/oslo/transformers/models/gpt2/modeling_gpt2.py
+++ b/oslo/transformers/models/gpt2/modeling_gpt2.py
@@ -118,7 +118,6 @@ class GPT2Attention(nn.Module):
 
         self.scale_attn_weights = config.scale_attn_weights
         self.is_cross_attention = is_cross_attention
-        self.use_triang_mask = not self.is_cross_attention
 
         # Layer-wise attention scaling, reordering, and upcasting
         self.scale_attn_by_inverse_layer_idx = config.scale_attn_by_inverse_layer_idx
@@ -175,7 +174,7 @@ class GPT2Attention(nn.Module):
         if F._is_fused_scale_mask_softmax_available(
             input=attn_weights,
             scale=scale_factor,
-            use_triang_mask=self.use_triang_mask,
+            use_triang_mask=self.is_cross_attention,
             softmax_in_fp32=self.softmax_in_fp32,
         ):
             attn_weights = F._fused_scale_mask_softmax_cuda(
@@ -265,9 +264,13 @@ class GPT2Attention(nn.Module):
             causal_mask = self.bias[
                 :, :, key_length - query_length : key_length, :key_length
             ].bool()
-            attn_weights = torch.where(
-                causal_mask, attn_weights, self.masked_bias.to(attn_weights.dtype)
+            mask_value = torch.finfo(attn_weights.dtype).min
+            # Need to be a tensor, otherwise we get error: `RuntimeError: expected scalar type float but found double`.
+            # Need to be on the same device, otherwise `RuntimeError: ..., x and y to be on the same device`
+            mask_value = torch.tensor(mask_value, dtype=attn_weights.dtype).to(
+                attn_weights.device
             )
+            attn_weights = torch.where(causal_mask, attn_weights, mask_value)
 
         if attention_mask is not None:
             # Apply the attention mask

--- a/tests/transformers/models/gpt2/test_modeling_gpt2.py
+++ b/tests/transformers/models/gpt2/test_modeling_gpt2.py
@@ -94,3 +94,9 @@ if __name__ == "__main__":
     oslo_model = GPT2Model.from_pretrained("gpt2", config=config)
     orig_model = TransformersGPT2Model.from_pretrained("gpt2", config=config)
     gradient_check(oslo_model, orig_model, return_logits=False)
+
+    config = AutoConfig.from_pretrained("gpt2")
+    config.softmax_in_fp32 = False  # default is True
+    oslo_model = GPT2Model.from_pretrained("gpt2", config=config)
+    orig_model = TransformersGPT2Model.from_pretrained("gpt2", config=config)
+    gradient_check(oslo_model, orig_model, return_logits=False)


### PR DESCRIPTION
Closes #62

## Title

- Coud use fused_scale_mask_softmax functionality on GPT2

## Description

- fused_scale_mask_softmax on `_attn` method only
- change `_fused_scale_mask_softmax_sanity_check`
- change configuration_gpt2.py 

## Linked Issues

- resolved #62 
