### PR TITLE
Renaming is fully_sharded_data_parallel.py

### DIFF
--- a/oslo/torch/nn/parallel/data_parallel/_fsdp/fully_sharded_data_parallel.py
+++ b/oslo/torch/nn/parallel/data_parallel/_fsdp/fully_sharded_data_parallel.py
@@ -76,7 +76,7 @@ from oslo.torch.distributed import ParallelMode
 from oslo.torch.nn.parallel.utils import add_wrapper
 
 from oslo.transformers.mapping_utils import (
-    _FullyShardedDataParallelMappingForHuggingFace,
+    _FullyShardedDataParallelMapping,
 )
 
 from torch.distributed.fsdp.wrap import (

--- a/oslo/torch/nn/parallel/data_parallel/_fsdp/fully_sharded_data_parallel.py
+++ b/oslo/torch/nn/parallel/data_parallel/_fsdp/fully_sharded_data_parallel.py
@@ -479,7 +479,7 @@ def FullyShardedDataParallel(
     mixed_precision: Optional[MixedPrecision] = None,
     cpu_offload: Optional[CPUOffload] = None,
 ):
-    fsdp_map_for_hf = _FullyShardedDataParallelMappingForHuggingFace()
+    fsdp_map_for_hf = _FullyShardedDataParallelMapping()
     transformer_layer_cls = fsdp_map_for_hf.get_mapping(module)
 
     if transformer_wrap_layers is not None:


### PR DESCRIPTION
## Title
This is solving: https://github.com/EleutherAI/oslo/issues/99
-

## Description
Is a simple rename in _fsp where _FullyShardedDataParallelMappingForHuggingFace was used instead of _FullyShardedDataParallelMapping
-

## Linked Issues

- resolved #00

After the change the test was running correctly: 
`
$ python -m torch.distributed.run --nproc_per_node=2 --master_port=2333 ./tests/torch/nn/parallel/data_parallel/test_fsdp.py 
WARNING:__main__:
*****************************************
Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
*****************************************
configs info : {'data_parallel_size': 2, 'pipeline_parallel_size': 1, 'sequence_parallel_size': 1, 'dataset_name': 'squad', 'model_name': 'gpt2', 'epochs': 1}
configs info : {'data_parallel_size': 2, 'pipeline_parallel_size': 1, 'sequence_parallel_size': 1, 'dataset_name': 'squad', 'model_name': 'gpt2', 'epochs': 1}
Found cached dataset squad (/fsx/home-jlopez/.cache/huggingface/datasets/squad/plain_text/1.0.0/d6ec3ceb99ca480ce37cdd35555d6cb2511d223b9150cce08a837ef62ffea453)
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 531.46it/s]
Found cached dataset squad (/fsx/home-jlopez/.cache/huggingface/datasets/squad/plain_text/1.0.0/d6ec3ceb99ca480ce37cdd35555d6cb2511d223b9150cce08a837ef62ffea453)
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 566.91it/s]
Found cached dataset squad (/fsx/home-jlopez/.cache/huggingface/datasets/squad/plain_text/1.0.0/d6ec3ceb99ca480ce37cdd35555d6cb2511d223b9150cce08a837ef62ffea453)
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 776.51it/s]
Found cached dataset squad (/fsx/home-jlopez/.cache/huggingface/datasets/squad/plain_text/1.0.0/d6ec3ceb99ca480ce37cdd35555d6cb2511d223b9150cce08a837ef62ffea453)
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 803.43it/s]
wandb: (1) Create a W&B account
wandb: (2) Use an existing W&B account
wandb: (3) Don't visualize my results
wandb: Enter your choice: 3
wandb: You chose 'Don't visualize my results'
wandb: Tracking run with wandb version 0.13.4
wandb: W&B syncing is set to `offline` in this directory.  
wandb: Run `wandb online` or set WANDB_MODE=online to enable cloud syncing.
wandb: Waiting for W&B process to finish... (success).
wandb: 
wandb: Run history:
wandb:    ddp Loss ▁
wandb: no_ddp Loss █▇▆▄▅▇▅▆▂▅▆▄▂▅▅▅▅▂▂▅▂▅▆▆▅▅▅▅▅▅▅▅▅▅▄▁▄▅▄▅
wandb: 
wandb: Run summary:
wandb:    ddp Loss 7.66082
wandb: no_ddp Loss 6.47143
wandb: 
wandb: You can sync this run to the cloud by running:
wandb: wandb sync /fsx/home-jlopez/oslo/wandb/offline-run-20221110_103926-1e2azpfi
`
