### PR TITLE
[Trainer] Oslo Config initialize

### DIFF
--- a/tests/transformers/trainer/test_oslo_config.py
+++ b/tests/transformers/trainer/test_oslo_config.py
@@ -15,12 +15,10 @@ oslo_init_dict_form = {
     "sequence_parallelism": {"enable": True, "parallel_size": 1},
 }
 
-user_config_from_dict = OsloTrainerConfig(oslo_init_dict_form)
-
-user_config_from_json = OsloTrainerConfig("oslo_user_config.json")
+user_config_from_dict = OsloTrainerConfig() # Test - user_config_from_dict not set
+#user_config_from_dict = OsloTrainerConfig(oslo_init_dict_form) # Test - user_config_from_dict is dict
+#user_config_from_json = OsloTrainerConfig("oslo_user_config.json") # Test - user_config_from_dict is str(oslo config file path)
 
 print(user_config_from_dict)
-
 res = init_oslo_features(user_config_from_dict)
-
 print(res)


### PR DESCRIPTION
## Title

- [Trainer] Oslo Config initialize

## Description

- inititialize when oslo config path or dict not setting 

##Checkpoint
- The default word size is set to "world_size = int(os.environ["WORLD_SIZE"])". Can I do this?
