### PR TITLE
[MOD] initialize when oslo config not setting

### DIFF
--- a/oslo/transformers/oslo_init.py
+++ b/oslo/transformers/oslo_init.py
@@ -220,23 +220,21 @@ class OsloTrainerConfig:
             with open(config_file_or_dict, "r", encoding="utf-8") as f:
                 cfg = json.load(f)
         else:
-            logging.warning(
-                "*you must initialize 'config_file_or_dict' parameter for oslo config. See SUPPORTED_FEATURES above*"
-            )
             cfg = {
                 "data_parallelism": {
-                    "enable": False,
-                    "parallel_size": 1,  # you can adjust parallel_size
+                    "enable": True,
+                    "parallel_size": 2,  # you can adjust parallel_size
                     "zero_stage": 0,  # zero_stage:0 -> original DDP
                 },
                 "tensor_parallelism": {
-                    "enable": False,
-                    "parallel_size": 1,
+                    "enable": True,
+                    "parallel_size": 2,
                     "parallel_mode": "1d",
                 },
                 "sequence_parallelism": {"enable": False, "parallel_size": 1},
                 "pipeline_parallelism": {"enable": False, "parallel_size": 1},
             }
+            raise ValueError(f"oslo config dict or oslo config file path must be set. \nSee example : {cfg}")
         _config_check(SUPPORTED_FEATURES, cfg)
         log_dist("*** OSLO CONFIG ***")
 

--- a/oslo/transformers/oslo_init.py
+++ b/oslo/transformers/oslo_init.py
@@ -223,11 +223,10 @@ class OsloTrainerConfig:
             logging.warning(
                 "*you must initialize 'config_file_or_dict' parameter for oslo config. See SUPPORTED_FEATURES above*"
             )
-            world_size = int(os.environ["WORLD_SIZE"])
             cfg = {
                 "data_parallelism": {
-                    "enable": True,
-                    "parallel_size": world_size,  # you can adjust parallel_size
+                    "enable": False,
+                    "parallel_size": 1,  # you can adjust parallel_size
                     "zero_stage": 0,  # zero_stage:0 -> original DDP
                 },
                 "tensor_parallelism": {

--- a/tests/transformers/trainer/test_oslo_config.py
+++ b/tests/transformers/trainer/test_oslo_config.py
@@ -1,6 +1,5 @@
 from oslo.transformers.oslo_init import OsloTrainerConfig, init_oslo_features
 
-
 oslo_init_dict_form = {
     "data_parallelism": {
         "enable": True,
@@ -15,12 +14,10 @@ oslo_init_dict_form = {
     "sequence_parallelism": {"enable": True, "parallel_size": 1},
 }
 
-user_config_from_dict = OsloTrainerConfig(oslo_init_dict_form)
-
-user_config_from_json = OsloTrainerConfig("oslo_user_config.json")
+user_config_from_dict = OsloTrainerConfig()  # Test - user_config_from_dict not set
+# user_config_from_dict = OsloTrainerConfig(oslo_init_dict_form) # Test - user_config_from_dict is dict
+# user_config_from_json = OsloTrainerConfig("oslo_user_config.json") # Test - user_config_from_dict is str(oslo config file path)
 
 print(user_config_from_dict)
-
 res = init_oslo_features(user_config_from_dict)
-
 print(res)


### PR DESCRIPTION
## Title

- [Trainer] Oslo Config initialize

## Description

- inititialize when oslo config path or dict not setting 

##Checkpoint
- default word size not set when oslo_config not setting (2022.12.07)

- The default word size is set to "world_size = int(os.environ["WORLD_SIZE"])". Can I do this?  (2022.12.02)

