### PR TITLE
Fix circular import for ZeRO optimizer

### DIFF
--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/__init__.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/__init__.py
@@ -1,4 +1,4 @@
-from oslo.torch.nn.parallel.data_parallel.zero.sharded_optim import (
+from oslo.torch.nn.parallel.data_parallel.zero.sharded_optim.sharded_optim import (
     ZeroRedundancyOptimizer,
 )
 


### PR DESCRIPTION
## Motivation
Related to #145 @yhna940 

```bash
$ pytest tests_deprecated/torch/nn/parallel/data_parallel/zero/
```

```
ImportError while importing test module '/home/oslo/tests_deprecated/torch/nn/parallel/data_parallel/zero/test_mixed_prec.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests_deprecated/torch/nn/parallel/data_parallel/zero/test_mixed_prec.py:13: in <module>
    from oslo.torch.nn.parallel.data_parallel.zero import ZeroRedundancyOptimizer
oslo/torch/nn/parallel/__init__.py:3: in <module>
    from oslo.torch.nn.parallel.data_parallel import *
oslo/torch/nn/parallel/data_parallel/__init__.py:1: in <module>
    from oslo.torch.nn.parallel.data_parallel.zero import *
oslo/torch/nn/parallel/data_parallel/zero/__init__.py:1: in <module>
    from oslo.torch.nn.parallel.data_parallel.zero.sharded_optim.sharded_optim import (
oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/__init__.py:1: in <module>
    from oslo.torch.nn.parallel.data_parallel.zero.sharded_optim import (
E   ImportError: cannot import name 'ZeroRedundancyOptimizer' from partially initialized module 'oslo.torch.nn.parallel.data_parallel.zero.sharded_optim' (most likely due to a circular import) (/home/oslo/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/__init__.py)
```