### PR TITLE
[Enhance] Support ViT for TensorParallel

### DIFF
--- a/oslo/torch/nn/parallel/tensor_parallel/tensor_parallel.py
+++ b/oslo/torch/nn/parallel/tensor_parallel/tensor_parallel.py
@@ -102,7 +102,7 @@ class _TensorParallel(OsloParallelWrapper):
 
         module = model.get_input_embeddings()
         if not hasattr(module, "weight"):
-            model.weight = None
+            module.weight = None
             return model
 
         vocab_size, embedding_dim = module.weight.size()

--- a/oslo/torch/nn/parallel/tensor_parallel/tensor_parallel.py
+++ b/oslo/torch/nn/parallel/tensor_parallel/tensor_parallel.py
@@ -101,6 +101,10 @@ class _TensorParallel(OsloParallelWrapper):
         ), "model object must have `get_input_embeddings` method."
 
         module = model.get_input_embeddings()
+        if not hasattr(module, "weight"):
+            model.weight = None
+            return model
+
         vocab_size, embedding_dim = module.weight.size()
         new_vocab_size = vocab_size
 

--- a/oslo/transformers/constants.py
+++ b/oslo/transformers/constants.py
@@ -9,6 +9,7 @@ BATCH_DIMENSIONS_TP = {
     "decoder_token_type_ids": 0,
     "decoder_position_ids": 0,
     "decoder_inputs_embeds": 0,
+    "pixel_values": 0,
 }
 
 BATCH_DIMENSIONS_PP = {

--- a/oslo/transformers/mapping_utils.py
+++ b/oslo/transformers/mapping_utils.py
@@ -35,7 +35,7 @@ class _ParallelMapping(object):
             transformers = importlib.import_module("transformers")
             cls = getattr(transformers, f"{model_name}PreTrainedModel", None)
             if cls is None:
-                cls = getattr(transformers, f"{model_name}", None)
+                cls = getattr(transformers, model_name, None)
             return cls
         except ImportError:
             return None
@@ -55,7 +55,7 @@ class _ParallelMapping(object):
             transformers = importlib.import_module("oslo.transformers")
             cls = getattr(transformers, f"{model_name}PreTrainedModel", None)
             if cls is None:
-                cls = getattr(transformers, f"{model_name}", None)
+                cls = getattr(transformers, model_name, None)
             return cls
         except ImportError:
             return None

--- a/oslo/transformers/mapping_utils.py
+++ b/oslo/transformers/mapping_utils.py
@@ -35,7 +35,7 @@ class _ParallelMapping(object):
             transformers = importlib.import_module("transformers")
             cls = getattr(transformers, f"{model_name}PreTrainedModel", None)
             if cls is None:
-                cls = getattr(transformers, f"{model_name}PretrainedModel", None)
+                cls = getattr(transformers, f"{model_name}", None)
             return cls
         except ImportError:
             return None
@@ -55,7 +55,7 @@ class _ParallelMapping(object):
             transformers = importlib.import_module("oslo.transformers")
             cls = getattr(transformers, f"{model_name}PreTrainedModel", None)
             if cls is None:
-                cls = getattr(transformers, f"{model_name}PretrainedModel", None)
+                cls = getattr(transformers, f"{model_name}", None)
             return cls
         except ImportError:
             return None
@@ -232,6 +232,15 @@ class _TensorParallelMapping(_ParallelMapping):
                 "qa_outputs",
                 gather_output=True,
             ),
+        ],
+        "ViTForImageClassification": [
+            Column("query", "key", "value", gather_output=True),
+            Column("intermediate.dense"),
+            Row("output.dense", gather_output=True),
+            Column("attention.output.dense", gather_output=True),
+            Other("position_embeddings", "cls_token", gather_output=True),
+            Update(""),
+            Head("classifier", gather_output=True),
         ],
     }
 

--- a/oslo/transformers/mapping_utils.py
+++ b/oslo/transformers/mapping_utils.py
@@ -234,12 +234,10 @@ class _TensorParallelMapping(_ParallelMapping):
             ),
         ],
         "ViTForImageClassification": [
-            Column("query", "key", "value", gather_output=True),
-            Column("intermediate.dense"),
-            Row("output.dense", gather_output=True),
-            Column("attention.output.dense", gather_output=True),
+            Column("query", "key", "value", "intermediate.dense"),
+            Row("output.dense"),
             Other("position_embeddings", "cls_token", gather_output=True),
-            Update(""),
+            Update("num_attention_heads", "all_head_size"),
             Head("classifier", gather_output=True),
         ],
     }


### PR DESCRIPTION
## Description

I added support for ViT in TensorParallel by appending config to `_TensorParallelMapping`.
`PatchEmbed` layer in ViT does not have the `weight` parameter unlike `Embedding` layer, so I replaced the `weight` parameter with a dummy value to prevent an `AttributeError`.

Any feedback is welcome.

### Memory usage
mode | world_size=1 | world_size=2 | world_size=4 | world_size=8
-|-|-|-|-
1D | 1760MiB | 1126MiB | 789MiB |
2D | | | 589MiB |
2.5D (d=1) | | | 589MiB |
2.5D (d=2) | | | | 586MiB
3D | | | |

### TODO
- [ ] Benchmark with `world_size=8`
- [ ] Refactor slicing patch embedding
- [ ] Fix slicing logic to return the same value as `TensorParallel1D`

<details><summary>code for testing</summary>
<p>

```python
import os
import torch.multiprocessing as mp

import torch
from torch import nn
from torch import optim
import torch.distributed as dist
from transformers import ViTModel, ViTForImageClassification, ViTConfig

import oslo
from oslo.torch.distributed.parallel_context import ParallelContext
from oslo.torch.distributed.parallel_mode import ParallelMode
from oslo.torch.nn.parallel import TensorParallel


def setup(rank, world_size):
    os.environ["MASTER_ADDR"] = "localhost"
    os.environ["MASTER_PORT"] = "12340"
    os.environ["RANK"] = str(rank)
    os.environ["LOCAL_RANK"] = str(rank)
    os.environ["WORLD_SIZE"] = str(world_size)
    os.environ["LOCAL_WORLD_SIZE"] = str(world_size)


def cleanup():
    dist.destroy_process_group()


def train(rank, world_size):
    print(f"Running oslo TP example on rank {rank}.")
    setup(rank, world_size)
    parallel_context = ParallelContext.from_torch(
        tensor_parallel_size=world_size,
        tensor_parallel_mode=ParallelMode.TENSOR_1D,
    )  # TENSOR2D or TENSOR_2P5D

    model = ViTForImageClassification(ViTConfig(num_labels=1000)).to(rank)
    model = TensorParallel(model, parallel_context)
    optimizer = optim.SGD(model.parameters(), lr=1e-4)
    loss_fn = nn.MSELoss()

    oslo.ready(model, parallel_context)

    for _ in range(100):
        model.zero_grad()
        logits = model(pixel_values=torch.ones(8, 3, 224, 224).to(rank)).logits
        labels = torch.ones(8, 1000).to(rank) * 100
        loss = loss_fn(logits, labels)
        loss.backward()
        optimizer.step()
        print(logits)
        print(torch.cuda.max_memory_allocated() / 1024**2)  # MB

    cleanup()


def main(world_size):
    mp.spawn(train, args=(world_size,), nprocs=world_size, join=True)


if __name__ == "__main__":
    main(4)
```

</p>
</details> 

## Linked Issues

Related to #152 