### PR TITLE
Add Apache License 2.0 copyright notice to ZeRO

### DIFF
--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/_base_optim.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/_base_optim.py
@@ -1,3 +1,20 @@
+# Copyright 2021 HPC-AI Technology Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Modified by EleutherAI on 2023.
+
+
 from torch.optim import Optimizer
 
 

--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/_utils.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/_utils.py
@@ -1,3 +1,19 @@
+# Copyright 2021 HPC-AI Technology Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Modified by EleutherAI on 2023.
+
 from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 import torch.distributed as dist
 from torch._six import inf

--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/bookkeeping/_base_store.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/bookkeeping/_base_store.py
@@ -1,3 +1,19 @@
+# Copyright 2021 HPC-AI Technology Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Modified by EleutherAI on 2023.
+
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
 

--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/bookkeeping/bucket_store.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/bookkeeping/bucket_store.py
@@ -1,3 +1,19 @@
+# Copyright 2021 HPC-AI Technology Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Modified by EleutherAI on 2023.
+
 from torch import Tensor
 from torch.distributed import ProcessGroup
 from typing import List

--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/bookkeeping/gradient_store.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/bookkeeping/gradient_store.py
@@ -1,3 +1,19 @@
+# Copyright 2021 HPC-AI Technology Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Modified by EleutherAI on 2023.
+
 from typing import List
 
 from torch import Tensor

--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/bookkeeping/parameter_store.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/bookkeeping/parameter_store.py
@@ -1,3 +1,19 @@
+# Copyright 2021 HPC-AI Technology Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Modified by EleutherAI on 2023.
+
 from typing import List, Dict
 
 from torch import Tensor

--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/bookkeeping/tensor_store.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/bookkeeping/tensor_store.py
@@ -1,3 +1,19 @@
+# Copyright 2021 HPC-AI Technology Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Modified by EleutherAI on 2023.
+
 from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 
 from torch import Tensor

--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/sharded_optim.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/sharded_optim.py
@@ -1,3 +1,19 @@
+# Copyright 2021 HPC-AI Technology Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Modified by EleutherAI on 2023.
+
 from functools import partial
 from typing import Optional, List, Callable
 


### PR DESCRIPTION
## Title

- Add ColossalAI Apache License 2.0 copyright notice to modified script 

## Description

- This PR adds the Apache License 2.0 copyright notice to the modified script from the ColossalAI project. The original script is under the Apache License 2.0, and as per the license requirements, we have included the original copyright notice, as well as an additional comment mentioning the modifications made by our organization.

##  Changes:
- Added Apache License 2.0 copyright notice to the modified script
- Included a comment to indicate the modifications made by our organization

Please review and let me know if any changes are required. Thanks!
