### PR TITLE
Wrong import in zero

### DIFF
--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/_utils.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/_utils.py
@@ -16,8 +16,7 @@
 
 from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 import torch.distributed as dist
-from torch import inf
-import math
+from math import sqrt, inf
 import torch
 from typing import Optional, Iterable, List, Union
 from oslo.torch.distributed import ParallelMode
@@ -78,7 +77,7 @@ def calculate_global_norm_from_list(norm_list: List[float]) -> float:
     total_norm = 0.0
     for norm in norm_list:
         total_norm += norm**2.0
-    return math.sqrt(total_norm)
+    return sqrt(total_norm)
 
 
 def reduce_tensor_dp_group(

--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/_utils.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/_utils.py
@@ -16,7 +16,7 @@
 
 from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 import torch.distributed as dist
-from torch._six import inf
+from torch import inf
 import math
 import torch
 from typing import Optional, Iterable, List, Union

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ packaging
 parameterized >= 0.8.1
 py-cpuinfo
 pybind11
-torch>=1.11.0
+torch >= 1.11.0
 transformers

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ packaging
 parameterized >= 0.8.1
 py-cpuinfo
 pybind11
-torch>=1.11.0,<2.0
+torch>=1.11.0
 transformers

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ packaging
 parameterized >= 0.8.1
 py-cpuinfo
 pybind11
-torch >= 1.11.0
+torch>=1.11.0,<2.0
 transformers


### PR DESCRIPTION
## Title

Prevent from using torch 2.0

## Description

- Some of feature have changed in torch 2.0. and oslo has dependency on torch._six which no longer support by torch 2.0.

olso Dependency
- https://github.com/EleutherAI/oslo/blob/910c789e7f46d2876b964c221d31984b7924974f/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/_utils.py#L19

other issues
- https://github.com/microsoft/DeepSpeed/issues/2845

## Linked Issues

- resolved #00
