### PR TITLE
Remove torch version 2.0.0 dependency in 

### DIFF
--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/_utils.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/_utils.py
@@ -13,15 +13,19 @@
 # limitations under the License.
 #
 # Modified by EleutherAI on 2023.
-
-from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
-import torch.distributed as dist
-from torch._six import inf
 import math
 import torch
+import torch.distributed as dist
+
+from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 from typing import Optional, Iterable, List, Union
 from oslo.torch.distributed import ParallelMode
 
+# deprecated torch._six in torch 2.0.0 version 
+if int(torch.__version__.split(".")[0]) < 2:
+    from torch._six import inf
+else:
+    from torch import inf
 
 def is_model_parallel_parameter(p: torch.Tensor) -> bool:
     """

--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/_utils.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/_utils.py
@@ -21,11 +21,13 @@ from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 from typing import Optional, Iterable, List, Union
 from oslo.torch.distributed import ParallelMode
 
-# deprecated torch._six in torch 2.0.0 version 
+# deprecated torch._six in torch 2.0.0 version
+# check torch version
 if int(torch.__version__.split(".")[0]) < 2:
     from torch._six import inf
 else:
     from torch import inf
+
 
 def is_model_parallel_parameter(p: torch.Tensor) -> bool:
     """


### PR DESCRIPTION
## Title

- Remove torch 2.0.0 version dependency in torch/nn/parallel/data_parallel/zero/sharded_optim/_utils.py

## Description

- Deprecated `torch._six` code since torch 2.0.0 version
- Torch issue link : https://github.com/pytorch/pytorch/pull/94709#issuecomment-1461471006

