### PR TITLE
fixed save_pretrained

### DIFF
--- a/oslo/torch/utils/extensions.py
+++ b/oslo/torch/utils/extensions.py
@@ -82,8 +82,8 @@ def save_pretrained(
                         use_residual=wrapper.use_residual,
                     )
 
-        model_to_save.load_state_dict(state_dict)
         oslo.ready(model_to_save, parallel_context=self.parallel_context)
+        model_to_save.load_state_dict(state_dict)
 
         if hasattr(model_to_save, "oslo_wrappers"):
             for parallel_mode, wrapper in model_to_save.oslo_wrappers.items():


### PR DESCRIPTION
## Title

- fixed_save_pretrained function

## Description

- After the design changed, save_pretrained works  not well
```
Traceback (most recent call last):
  File "test_wrapper_1d.py", line 47, in <module>
    wrapper_tp.save_pretrained(save_directory="test", merge_checkpoints=True)
  File "/fsx/kevin.ai/Anaconda/envs/oslo/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/fsx/kevin.ai/oslo/oslo/torch/utils/extensions.py", line 85, in save_pretrained
    model_to_save.load_state_dict(state_dict)
  File "/fsx/kevin.ai/Anaconda/envs/oslo/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1671, in load_state_dict
    raise RuntimeError('Error(s) in loading state_dict for {}:\n\t{}'.format(
RuntimeError: Error(s) in loading state_dict for GPTNeoXForCausalLM:
	size mismatch for gpt_neox.embed_in.weight: copying a param with shape torch.Size([7520, 2048]) from checkpoint, the shape in current model is torch.Size([30080, 2048]).
	size mismatch for gpt_neox.layers.0.attention.query_key_value.weight: copying a param with shape torch.Size([1536, 2048]) from checkpoint, the shape in current model is torch.Size([6144, 2048]).
	size mismatch for gpt_neox.layers.0.attention.query_key_value.bias: copying a param with shape torch.Size([1536]) from checkpoint, the shape in current model is torch.Size([6144]).
	size mismatch for gpt_neox.layers.0.attention.dense.weight: copying a param with shape torch.Size([2048, 512]) from checkpoint, the shape in current model is torch.Size([2048, 2048]).
	size mismatch for gpt_neox.layers.0.mlp.dense_h_to_4h.weight: copying a param with shape torch.Size([2048, 2048]) from checkpoint, the shape in current model is torch.Size([8192, 2048]).
	size mismatch for gpt_neox.layers.0.mlp.dense_h_to_4h.bias: copying a param with shape torch.Size([2048]) from checkpoint, the shape in current model is torch.Size([8192]).
	size mismatch for gpt_neox.layers.0.mlp.dense_4h_to_h.weight: copying a param with shape torch.Size([2048, 2048]) from checkpoint, the shape in current model is torch.Size([2048, 8192]).
```

So I was fixed this features.

## Linked Issues

- resolved #00
