### PR TITLE
[zero] Suggests a minor change to confusing variable names in the ZeRO optimizer

### DIFF
--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/_utils.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/_utils.py
@@ -258,7 +258,7 @@ def compute_norm(
     return total_norm
 
 
-def split_half_float_double(
+def split_by_dtype(
     tensor_list: List[torch.Tensor],
 ) -> List[List[torch.Tensor]]:
     """

--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/bookkeeping/parameter_store.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/bookkeeping/parameter_store.py
@@ -119,9 +119,7 @@ class ParameterStore(BaseStore):
         """
         return self._rank_group_id_to_param_list[rank][group_id]
 
-    def add_flat_param_by_rank_group(
-        self, rank: int, group_id: int, tensor: Tensor
-    ):
+    def add_flat_param_by_rank_group(self, rank: int, group_id: int, tensor: Tensor):
         """
         Add a flat parameter by rank and group.
 

--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/sharded_optim.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/sharded_optim.py
@@ -31,7 +31,7 @@ from oslo.torch.nn.parallel.data_parallel.zero.sharded_optim._utils import (
     has_inf_or_nan,
     reduce_tensor_dp_group,
     release_param_grad,
-    split_half_float_double,
+    split_by_dtype,
     sync_param,
 )
 
@@ -81,9 +81,8 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
         """
 
         # TODO: add support for
-        # 1. fp16 master weights
-        # 2. contiguous gradients
-        # 3. support when some parameters requires_grad = False
+        # 1. contiguous gradients
+        # 2. support when some parameters requires_grad = False
         super(ZeroRedundancyOptimizer, self).__init__(optim=optimizer)
         self._dtype = self.optim.param_groups[0]["params"][0].dtype
 
@@ -103,9 +102,9 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
         else:
             self._mp_torch_group = None
 
-        # fp16 and fp32 params for mixed precision training
-        self._fp16_param_groups = dict()
-        self._fp32_flat_param_groups_of_current_rank = dict()
+        # working and master params for mixed precision training
+        self._working_param_groups = dict()
+        self._master_flat_param_groups_of_current_rank = dict()
 
         # communication params
         self._overlap_communication = overlap_communication
@@ -139,8 +138,8 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
         for group_id, param_group in enumerate(self.optim.param_groups):
             group_params = param_group["params"]
 
-            # add the fp16 params to fp16_param_groups for bookkeeping
-            self._fp16_param_groups[group_id] = group_params
+            # add the working params to working_param_groups for bookkeeping
+            self._working_param_groups[group_id] = group_params
 
             # assign parameters to ranks
             # the params in the list are sorted
@@ -149,9 +148,7 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
             # store the mapping between param to rank
             # each param should belong to only one rank
             for rank, params in enumerate(params_per_rank):
-                self._param_store.add_fp16_param_list_by_rank_group(
-                    rank, group_id, params
-                )
+                self._param_store.add_param_list_by_rank_group(rank, group_id, params)
                 for param in params:
                     self._param_store.set_param_to_rank(param, rank)
 
@@ -162,47 +159,41 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
 
             # flatten the reordered tensors
             for rank in range(self._world_size):
-                tensor_list = self._param_store.get_fp16_params_by_rank_group(
-                    rank, group_id
-                )
+                tensor_list = self._param_store.get_params_by_rank_group(rank, group_id)
                 with torch.no_grad():
                     flat_tensor = flatten(tensor_list)
                 flat_tensor = flat_tensor.data.cuda()
-                self._param_store.add_flat_fp16_param_by_rank_group(
+                self._param_store.add_flat_param_by_rank_group(
                     rank, group_id, flat_tensor
                 )
 
             # sync parameters
             for rank in range(self._world_size):
-                flat_tensor = self._param_store.get_flat_fp16_param_by_rank_group(
+                flat_tensor = self._param_store.get_flat_param_by_rank_group(
                     rank, group_id
                 )
-                tensor_list = self._param_store.get_fp16_params_by_rank_group(
-                    rank, group_id
-                )
+                tensor_list = self._param_store.get_params_by_rank_group(rank, group_id)
                 sync_param(flat_tensor=flat_tensor, tensor_list=tensor_list)
 
-            # create a copy of fp32 weights of the parameters for which this rank is responsible
-            fp16_flat_current_rank = (
-                self._param_store.get_flat_fp16_param_by_rank_group(
-                    self._local_rank, group_id
-                )
+            # create a copy of master weights of the parameters for which this rank is responsible
+            working_flat_current_rank = self._param_store.get_flat_param_by_rank_group(
+                self._local_rank, group_id
             )
-            fp32_flat_current_rank = fp16_flat_current_rank.float()
+            master_flat_current_rank = working_flat_current_rank.float()
             device = "cpu" if self._cpu_offload else torch.cuda.current_device()
-            fp32_flat_current_rank = fp32_flat_current_rank.to(device)
-            fp32_flat_current_rank.requires_grad = True
-            self._fp32_flat_param_groups_of_current_rank[
+            master_flat_current_rank = master_flat_current_rank.to(device)
+            master_flat_current_rank.requires_grad = True
+            self._master_flat_param_groups_of_current_rank[
                 group_id
-            ] = fp32_flat_current_rank
+            ] = master_flat_current_rank
 
             # need to replace the params in the `params` field in the optimizer
             # so that when the optimizer calls step(), it only updates the tensors
             # managed by this data parallel rank
-            param_group["params"] = [fp32_flat_current_rank]
+            param_group["params"] = [master_flat_current_rank]
 
             # set reduction state
-            for param in self._fp16_param_groups[group_id]:
+            for param in self._working_param_groups[group_id]:
                 self._param_store.set_param_reduction_state(param, False)
 
         # initialize communication stream for
@@ -226,7 +217,7 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
     @property
     def num_param_groups(self) -> int:
         """Returns the number of parameter groups in the optimizer."""
-        return len(self._fp16_param_groups)
+        return len(self._working_param_groups)
 
     def _sanity_checks(self):
         """Performs sanity checks for the optimizer.
@@ -293,10 +284,10 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
 
     def _attach_reduction_bucket_hook(self):
         """Attaches gradient reduction hook to each model parameter."""
-        # we iterate over the fp16 params
+        # we iterate over the working params
         # on each param, we register a hook to its AccumulateGrad object
         for group_id in range(self.num_param_groups):
-            param_group = self._fp16_param_groups[group_id]
+            param_group = self._working_param_groups[group_id]
             for param in param_group:
                 if param.requires_grad:
                     # determines the reduction destination rank
@@ -322,7 +313,7 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
         hook_count_target = sum(
             1
             for group_id in range(self.num_param_groups)
-            for param in self._fp16_param_groups[group_id]
+            for param in self._working_param_groups[group_id]
             if param.requires_grad
         )
         assert (
@@ -356,7 +347,7 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
                 return grad
 
         for group_id in range(self.num_param_groups):
-            for param in self._fp16_param_groups[group_id]:
+            for param in self._working_param_groups[group_id]:
                 if param.requires_grad:
                     param.register_hook(partial(hook, param))
 
@@ -427,7 +418,7 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
             grads (List[Tensor]): List of gradients to reduce.
             bucket_size (int): Size of the bucket.
         """
-        grad_buckets_by_dtype = split_half_float_double(grads)
+        grad_buckets_by_dtype = split_by_dtype(grads)
 
         for tensor_list in grad_buckets_by_dtype:
             self._reduce_tensor_list_with_one_dtype(
@@ -540,7 +531,7 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
         Args:
             set_to_none (bool): Whether set the gradient to None. Default value is True.
         """
-        for _, param_group in self._fp16_param_groups.items():
+        for _, param_group in self._working_param_groups.items():
             for param in param_group:
                 if set_to_none:
                     param.grad = None
@@ -572,7 +563,7 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
             self.zero_grad()
             return
 
-        # copy the grad of fp16 param to fp32 param
+        # copy the grad of working param to master param
         single_grad_partition_groups = []
         norm_groups = []
 
@@ -580,7 +571,7 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
             # compute norm
             norm_group = compute_norm(
                 gradients=self._grad_store.get_averaged_gradients_by_group(group_id),
-                params=self._param_store.get_fp16_params_by_rank_group(
+                params=self._param_store.get_params_by_rank_group(
                     group_id=group_id, rank=self._local_rank
                 ),
                 dp_group=self._dp_torch_group,
@@ -588,61 +579,63 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
             )
             norm_groups.append(norm_group)
 
-            # create flat gradient for the flat fp32 params
-            fp16_avg_grads = self._grad_store.get_averaged_gradients_by_group(group_id)
-            flat_fp16_avg_grads = flatten(fp16_avg_grads)
-
-            dtype = self._fp32_flat_param_groups_of_current_rank[group_id].dtype
-            flat_fp32_avg_grads = flat_fp16_avg_grads.to(dtype)
-
-            param_shape = self._fp32_flat_param_groups_of_current_rank[group_id].shape
-            assert (
-                param_shape == flat_fp32_avg_grads.shape
-            ), f"fp32 param and grad have different shape {param_shape} vs {flat_fp32_avg_grads.shape}"
-
-            single_grad_partition_groups.append(flat_fp32_avg_grads)
-            device = self._fp32_flat_param_groups_of_current_rank[group_id].device
-            self._fp32_flat_param_groups_of_current_rank[
+            # create flat gradient for the flat master params
+            working_avg_grads = self._grad_store.get_averaged_gradients_by_group(
                 group_id
-            ].grad = flat_fp32_avg_grads.to(device)
+            )
+            flat_working_avg_grads = flatten(working_avg_grads)
+
+            dtype = self._master_flat_param_groups_of_current_rank[group_id].dtype
+            flat_master_avg_grads = flat_working_avg_grads.to(dtype)
+
+            param_shape = self._master_flat_param_groups_of_current_rank[group_id].shape
+            assert (
+                param_shape == flat_master_avg_grads.shape
+            ), f"master param and grad have different shape {param_shape} vs {flat_master_avg_grads.shape}"
+
+            single_grad_partition_groups.append(flat_master_avg_grads)
+            device = self._master_flat_param_groups_of_current_rank[group_id].device
+            self._master_flat_param_groups_of_current_rank[
+                group_id
+            ].grad = flat_master_avg_grads.to(device)
             self._grad_store.reset_average_gradients_by_group(group_id)
 
-        # unscale and clip grads
+        # clip grads
         global_norm = calculate_global_norm_from_list(norm_list=norm_groups)
-        self._unscale_and_clip_grads(single_grad_partition_groups, global_norm)
+        self._clip_grads(single_grad_partition_groups, global_norm)
 
         # update the parameters
         self.optim.step()
-        # release the fp32 grad
-        release_param_grad(self._fp32_flat_param_groups_of_current_rank.values())
+        # release the master grad
+        release_param_grad(self._master_flat_param_groups_of_current_rank.values())
 
-        # update fp16 partition updated by the current rank
-        for group_id in range(len(self._fp16_param_groups)):
-            fp16_param = self._param_store.get_flat_fp16_param_by_rank_group(
+        # update working partition updated by the current rank
+        for group_id in range(len(self._working_param_groups)):
+            working_param = self._param_store.get_flat_param_by_rank_group(
                 rank=self._local_rank, group_id=group_id
             )
-            fp32_param = self._fp32_flat_param_groups_of_current_rank[group_id]
-            fp16_param.data.copy_(fp32_param)
+            master_param = self._master_flat_param_groups_of_current_rank[group_id]
+            working_param.data.copy_(master_param)
 
         # broadcast the updated model weights
         handles = []
         for group_id in range(self.num_param_groups):
             for index in range(self._world_size):
                 rank = self._dp_global_ranks[index]
-                fp16_param = self._param_store.get_flat_fp16_param_by_rank_group(
+                working_param = self._param_store.get_flat_param_by_rank_group(
                     rank=index, group_id=group_id
                 )
                 handle = dist.broadcast(
-                    fp16_param, src=rank, group=self._dp_torch_group, async_op=True
+                    working_param, src=rank, group=self._dp_torch_group, async_op=True
                 )
                 handles.append(handle)
 
         for handle in handles:
             handle.wait()
 
-    ##################
-    # FP16 Utilities #
-    ##################
+    #############################
+    # Mixed Precision Utilities #
+    #############################
 
     def _check_overflow(self):
         """check for the presence of numerical overflow
@@ -655,7 +648,7 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
         self._found_overflow.fill_(0.0)
 
         # check for overflow
-        for group_id in range(len(self._fp16_param_groups)):
+        for group_id in range(len(self._working_param_groups)):
             for avg_grad in self._grad_store.get_averaged_gradients_by_group(group_id):
                 if avg_grad is not None and has_inf_or_nan(avg_grad):
                     self._found_overflow.fill_(1.0)
@@ -677,9 +670,9 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
         else:
             return False
 
-    def _unscale_and_clip_grads(self, grad_groups_flat: List, total_norm: float):
+    def _clip_grads(self, grad_groups_flat: List, total_norm: float):
         """
-        Unscale the gradient norms and clip them if the `clip_grad_norm` argument is provided.
+        Clip the gradient if the `clip_grad_norm` argument is provided.
 
         Args:
             grad_groups_flat (List): List of PyTorch tensors representing the gradient.
@@ -706,7 +699,7 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
 
         # accumulate gradient
         for group_id in range(self.num_param_groups):
-            param_group = self._param_store.get_fp16_params_by_rank_group(
+            param_group = self._param_store.get_params_by_rank_group(
                 self._local_rank, group_id
             )
 
@@ -738,8 +731,8 @@ class ZeroRedundancyOptimizer(BaseOptimizerWrapper):
         # if not overlapping communication (no reduction hook is attached)
         # we need to manually reduce these gradients
         if not self._overlap_communication:
-            for group_id in range(len(self._fp16_param_groups)):
-                param_group = self._fp16_param_groups[group_id]
+            for group_id in range(len(self._working_param_groups)):
+                param_group = self._working_param_groups[group_id]
                 for param in param_group:
                     if param.grad is not None:
                         self._add_to_reduction_bucket(param)


### PR DESCRIPTION
## Title

- [zero] Suggests a minor change to confusing variable names in the ZeRO optimizer

## Description

It seems that the variable names related to the mixed precision parameter group do not comprehensively cover its characteristics, so I suggest a few changes. These changes are very trivial, but hopefully they will alleviate some of the confusion for beginners like me.

Currently, the entire parameter group is named `fp16_param_groups`, and the parts managed by the gpu at the current rank are described as `fp32_flat_param_groups_of_current_rank`. This state perfectly represents the characteristics when the master weight is a half-tensor or the dtype specified in the `__init__`method is fp16. In other cases, however, its characteristics do not correspond to the variable it.

 I would like to propose an alternative term, `working_param` and `master_param`. The term is more closely related to the concept of the mixed-precision training context. Using `working_param` and `master_weight` would create a clear distinction between the two types of parameters and help avoid confusion.

To summarize my suggestions:
- `fp16` -> `working`
- `fp32` -> `master`


## Linked Issues

- N/A

## Reference

- https://github.com/hpcaitech/ColossalAI/pull/3173
