### PR TITLE
[Fix] Minor Issues in Data Parallel and Chunk Utils

### DIFF
--- a/oslo/torch/nn/parallel/data_parallel/data_parallel.py
+++ b/oslo/torch/nn/parallel/data_parallel/data_parallel.py
@@ -96,8 +96,8 @@ class _DistributedDataParallel(OsloParallelWrapper):
                 {
                     k: v
                     for k, v in zip(
-                        outputs.keys(),
-                        DistributedBackwardFunction.apply(self, *outputs.values()),
+                        inputs.keys(),
+                        DistributedBackwardFunction.apply(self, *inputs.values()),
                     )
                 }
             )

--- a/oslo/torch/nn/parallel/data_parallel/zero/__init__.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/__init__.py
@@ -4,5 +4,12 @@ from oslo.torch.nn.parallel.data_parallel.zero.sharded_optim.sharded_optim impor
 from oslo.torch.nn.parallel.data_parallel.zero.fully_sharded_data_parallel import (
     _FullyShardedDataParallel,
 )
+from oslo.torch.nn.parallel.data_parallel.zero.sharded_optim.heterogeneous_optim import (
+    _HeterogeneousZeroOptimizer,
+)
 
-__ALL__ = ["ZeroRedundancyOptimizer"]
+__ALL__ = [
+    "ZeroRedundancyOptimizer",
+    "_FullyShardedDataParallel",
+    "_HeterogeneousZeroOptimizer",
+]

--- a/oslo/torch/nn/parallel/data_parallel/zero/chunk/utils.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/chunk/utils.py
@@ -27,6 +27,9 @@ from oslo.torch.nn.parallel.data_parallel.zero.memory_tracer import (
 )
 from oslo.torch.distributed.parallel_mode import ParallelMode
 
+from oslo.torch.distributed.parallel_context import ParallelContext
+from oslo.torch.distributed.parallel_mode import ParallelMode
+
 
 def _filter_exlarge_params(model: nn.Module, size_dict: Dict[int, List[int]]):
     """
@@ -114,7 +117,7 @@ def classify_params_by_dp_degree(
             continue
 
         if strict_ddp_flag or type(param) is not DistributedParameter:
-            param_key = dist.get_world_size()
+            param_key = ParallelContext.get_context().get_world_size(ParallelMode.DATA)
         else:
             param_key = param.parallel_context.get_world_size(ParallelMode.DATA)
 

--- a/oslo/torch/nn/parallel/data_parallel/zero/fully_sharded_data_parallel.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/fully_sharded_data_parallel.py
@@ -614,7 +614,6 @@ class _FullyShardedDataParallel(_DistributedDataParallel):
     def _init_chunks(
         self, param_order, strict_ddp_mode: bool, cpu_offload: bool, pin_memory: bool
     ):
-        ddp_pg = self.parallel_context.get_group(ParallelMode.DATA)
         for p in param_order.generate():
             self._preprocess_param(p)
             assert isinstance(p, DistributedParameter)
@@ -623,7 +622,7 @@ class _FullyShardedDataParallel(_DistributedDataParallel):
             if strict_ddp_mode:
                 if not p.is_replicate():
                     p.set_dist_spec(ReplicaSpec())
-                p.set_parallel_context(pg=ddp_pg)
+                p.set_parallel_context(parallel_context=self.parallel_context)
 
             # ignore the parameters with no gradient
             if not p.requires_grad:

--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/__init__.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/__init__.py
@@ -3,8 +3,8 @@ from oslo.torch.nn.parallel.data_parallel.zero.sharded_optim.sharded_optim impor
 )
 
 from oslo.torch.nn.parallel.data_parallel.zero.sharded_optim.heterogeneous_optim import (
-    HeterogeneousZeroOptimizer,
+    _HeterogeneousZeroOptimizer,
 )
 
 
-__ALL__ = ["ZeroRedundancyOptimizer", "HeterogeneousZeroOptimizer"]
+__ALL__ = ["ZeroRedundancyOptimizer", "_HeterogeneousZeroOptimizer"]

--- a/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/heterogeneous_optim.py
+++ b/oslo/torch/nn/parallel/data_parallel/zero/sharded_optim/heterogeneous_optim.py
@@ -45,11 +45,11 @@ def _disposable(func: Callable) -> Callable:
     return wrapper
 
 
-class HeterogeneousZeroOptimizer(BaseOptimizerWrapper):
-    """A wrapper for optimizer. ``_FullyShardedDataParallel`` and ``HeterogeneousZeroOptimizer`` implement Zero Redundancy Optimizer (ZeRO state-3).
+class _HeterogeneousZeroOptimizer(BaseOptimizerWrapper):
+    """A wrapper for optimizer. ``_FullyShardedDataParallel`` and ``_HeterogeneousZeroOptimizer`` implement Zero Redundancy Optimizer (ZeRO state-3).
 
     Note:
-        You must use ``_FullyShardedDataParallel`` with ``HeterogeneousZeroOptimizer``.
+        You must use ``_FullyShardedDataParallel`` with ``_HeterogeneousZeroOptimizer``.
 
     Note:
         Make sure you set ``placement_policy`` of ``heterogeneousManager`` to `"auto"`,


### PR DESCRIPTION
## Title

- [Fix] Minor Issues in Data Parallel and Chunk Utils

## Description

-

## Linked Issues

- N/A

```python
import logging
import os
import torch
import torch.nn as nn
import torch.optim as optim
import torch.distributed as dist
import torch.multiprocessing as mp
from torch.utils.data import DataLoader, DistributedSampler
from transformers import DistilBertTokenizerFast, DistilBertForSequenceClassification
from datasets import load_dataset

from oslo.torch.distributed.parallel_context import ParallelContext
from oslo.torch.nn.parallel.data_parallel.zero import _FullyShardedDataParallel
from oslo.torch.nn.parallel.data_parallel.zero.sharded_optim.heterogeneous_optim import (
    _HeterogeneousZeroOptimizer,
)

def setup(rank, world_size):
    os.environ['MASTER_ADDR'] = 'localhost'
    os.environ['MASTER_PORT'] = '12345'
    os.environ["RANK"] = str(rank)
    os.environ["LOCAL_RANK"] = str(rank)
    os.environ["WORLD_SIZE"] = str(world_size)
    os.environ["LOCAL_WORLD_SIZE"] = str(world_size)
    return ParallelContext.from_torch(data_parallel_size=world_size)

# Set up logger
class DistLogger:
    def __init__(self, log_file_path):
        self.logger = logging.getLogger(__name__)
        self.logger.setLevel(logging.DEBUG)
        formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
        file_handler = logging.FileHandler(log_file_path)
        file_handler.setLevel(logging.DEBUG)
        file_handler.setFormatter(formatter)
        self.logger.addHandler(file_handler)

    def debug(self, msg, *args, **kwargs):
        if dist.get_rank() == 0:
            self.logger.debug(msg, *args, **kwargs)

    def info(self, msg, *args, **kwargs):
        if dist.get_rank() == 0:
            self.logger.info(msg, *args, **kwargs)

    def warning(self, msg, *args, **kwargs):
        if dist.get_rank() == 0:
            self.logger.warning(msg, *args, **kwargs)

    def error(self, msg, *args, **kwargs):
        if dist.get_rank() == 0:
            self.logger.error(msg, *args, **kwargs)

    def critical(self, msg, *args, **kwargs):
        if dist.get_rank() == 0:
            self.logger.critical(msg, *args, **kwargs)
            
logger = DistLogger('zero-tp-training.log')

# Load the IMDb dataset
dataset_train = load_dataset('imdb', split='train')
dataset_val = load_dataset('imdb', split='test[:50%]')
dataset_test = load_dataset('imdb', split='test[50%:]')

train_texts = dataset_train['text']
train_labels = dataset_train['label']
val_texts = dataset_val['text']
val_labels = dataset_val['label']
test_texts = dataset_test['text']
test_labels = dataset_test['label']

# Set up tokenizer
tokenizer = DistilBertTokenizerFast.from_pretrained('distilbert-base-uncased')

train_encodings = tokenizer(train_texts, truncation=True, padding=True)
val_encodings = tokenizer(val_texts, truncation=True, padding=True)
test_encodings = tokenizer(test_texts, truncation=True, padding=True)

# Prepare the PyTorch Dataset
class IMDbDataset(torch.utils.data.Dataset):
    def __init__(self, encodings, labels):
        self.encodings = encodings
        self.labels = labels

    def __getitem__(self, idx):
        item = {key: torch.tensor(val[idx]) for key, val in self.encodings.items()}
        item['labels'] = torch.tensor(self.labels[idx])
        return item

    def __len__(self):
        return len(self.labels)


# Set up distributed training
def train(rank, world_size):
    parallel_context = setup(rank, world_size)
    dist.barrier()

    # Set up the model
    device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
    model = DistilBertForSequenceClassification.from_pretrained('distilbert-base-uncased')
    if torch.cuda.is_available() and torch.cuda.device_count() > 1:
        model = _FullyShardedDataParallel(model, device, parallel_context=parallel_context)
        model.parallelize()
    else:
        raise Exception

    # Set up optimizer
    optimizer = optim.AdamW(model.parameters(), lr=5e-5)
    optimizer = _HeterogeneousZeroOptimizer(optimizer, model)

    # Load data
    train_dataset = IMDbDataset(train_encodings, train_labels)
    val_dataset = IMDbDataset(val_encodings, val_labels)
    test_dataset = IMDbDataset(test_encodings, test_labels)

    if torch.cuda.is_available() and torch.cuda.device_count() > 1:
        train_sampler = DistributedSampler(train_dataset, num_replicas=world_size, rank=rank)
        train_loader = DataLoader(train_dataset, batch_size=16, sampler=train_sampler)
        val_loader = DataLoader(val_dataset, batch_size=64)
        test_loader = DataLoader(test_dataset, batch_size=64)
    else:
        raise Exception

    num_epochs = 8
    for epoch in range(num_epochs):
        # Training loop
        model.train()
        for idx, batch in enumerate(train_loader):
            optimizer.zero_grad()
            input_ids = batch['input_ids'].to(device)
            attention_mask = batch['attention_mask'].to(device)
            labels = batch['labels'].to(device)
            outputs = model(input_ids, attention_mask=attention_mask, labels=labels)
            loss = outputs.loss
            loss.backward()
            optimizer.step()
            if idx % 100 == 0:
                logger.info(f'Epoch {epoch} Iter {idx}: loss = {loss.item():.4f}, memory = {torch.cuda.memory_allocated() / 1024 / 1024:.4f}')

        # Evaluation loop
        model.eval()
        correct = 0
        total = 0
        for batch in val_loader:
            input_ids = batch['input_ids'].to(device)
            attention_mask = batch['attention_mask'].to(device)
            labels = batch['labels'].to(device)
            outputs = model(input_ids, attention_mask=attention_mask, labels=labels)
            predictions = outputs.logits.argmax(dim=-1)
            correct += (predictions == labels).sum().item()
            total += labels.shape[0]
        accuracy = correct / total
        logger.info(f'Epoch {epoch}: validation accuracy = {accuracy:.4f}')

    # Evaluate the model on the test set
    model.eval()
    correct = 0
    total = 0
    for batch in test_loader:
        input_ids = batch['input_ids'].to(device)
        attention_mask = batch['attention_mask'].to(device)
        labels = batch['labels'].to(device)
        outputs = model(input_ids, attention_mask=attention_mask, labels=labels)
        predictions = outputs.logits.argmax(dim=-1)
        correct += (predictions == labels).sum().item()
        total += labels.shape[0]
    accuracy = correct / total
    logger.info(f'Test accuracy = {accuracy:.4f}')

if __name__ == '__main__':
    world_size = 4
    mp.spawn(train, args=(world_size,), nprocs=world_size, join=True)
```

```
2023-05-16 15:14:39,469 - INFO - Epoch 0 Iter 0: loss = 0.6963, memory = 296.3750
2023-05-16 15:14:44,846 - INFO - Epoch 0 Iter 100: loss = 0.7173, memory = 296.3750
2023-05-16 15:14:50,274 - INFO - Epoch 0 Iter 200: loss = 0.1230, memory = 296.3750
2023-05-16 15:14:55,833 - INFO - Epoch 0 Iter 300: loss = 0.0365, memory = 296.3750
2023-05-16 15:15:10,735 - INFO - Epoch 0: validation accuracy = 0.8652
2023-05-16 15:15:10,799 - INFO - Epoch 1 Iter 0: loss = 0.1324, memory = 296.3755
2023-05-16 15:15:16,058 - INFO - Epoch 1 Iter 100: loss = 0.3147, memory = 296.3755
2023-05-16 15:15:21,334 - INFO - Epoch 1 Iter 200: loss = 0.0644, memory = 296.3755
2023-05-16 15:15:26,647 - INFO - Epoch 1 Iter 300: loss = 0.0399, memory = 296.3755
2023-05-16 15:15:40,475 - INFO - Epoch 1: validation accuracy = 0.9308
2023-05-16 15:15:40,534 - INFO - Epoch 2 Iter 0: loss = 0.0753, memory = 296.3755
2023-05-16 15:15:45,846 - INFO - Epoch 2 Iter 100: loss = 0.0559, memory = 296.3755
2023-05-16 15:15:50,935 - INFO - Epoch 2 Iter 200: loss = 0.0348, memory = 296.3755
2023-05-16 15:15:55,950 - INFO - Epoch 2 Iter 300: loss = 0.0966, memory = 296.3755
2023-05-16 15:16:10,370 - INFO - Epoch 2: validation accuracy = 0.9485
2023-05-16 15:16:10,425 - INFO - Epoch 3 Iter 0: loss = 0.0105, memory = 296.3755
2023-05-16 15:16:15,538 - INFO - Epoch 3 Iter 100: loss = 0.2773, memory = 296.3755
2023-05-16 15:16:20,630 - INFO - Epoch 3 Iter 200: loss = 0.0338, memory = 296.3755
2023-05-16 15:16:25,726 - INFO - Epoch 3 Iter 300: loss = 0.0043, memory = 296.3755
2023-05-16 15:16:39,352 - INFO - Epoch 3: validation accuracy = 0.9502
2023-05-16 15:16:39,485 - INFO - Epoch 4 Iter 0: loss = 0.1733, memory = 296.3755
2023-05-16 15:16:44,478 - INFO - Epoch 4 Iter 100: loss = 0.0780, memory = 296.3755
2023-05-16 15:16:49,464 - INFO - Epoch 4 Iter 200: loss = 0.0033, memory = 296.3755
2023-05-16 15:16:54,584 - INFO - Epoch 4 Iter 300: loss = 0.0024, memory = 296.3755
2023-05-16 15:17:08,122 - INFO - Epoch 4: validation accuracy = 0.9454
2023-05-16 15:17:08,219 - INFO - Epoch 5 Iter 0: loss = 0.0012, memory = 296.3755
2023-05-16 15:17:13,227 - INFO - Epoch 5 Iter 100: loss = 0.0009, memory = 296.3755
2023-05-16 15:17:18,228 - INFO - Epoch 5 Iter 200: loss = 0.0257, memory = 296.3755
2023-05-16 15:17:23,215 - INFO - Epoch 5 Iter 300: loss = 0.0222, memory = 296.3755
2023-05-16 15:17:36,728 - INFO - Epoch 5: validation accuracy = 0.9538
2023-05-16 15:17:36,792 - INFO - Epoch 6 Iter 0: loss = 0.0047, memory = 296.3755
2023-05-16 15:17:42,046 - INFO - Epoch 6 Iter 100: loss = 0.0268, memory = 296.3755
2023-05-16 15:17:47,275 - INFO - Epoch 6 Iter 200: loss = 0.0058, memory = 296.3755
2023-05-16 15:17:52,547 - INFO - Epoch 6 Iter 300: loss = 0.0041, memory = 296.3755
2023-05-16 15:18:06,470 - INFO - Epoch 6: validation accuracy = 0.9501
2023-05-16 15:18:06,536 - INFO - Epoch 7 Iter 0: loss = 0.0007, memory = 296.3755
2023-05-16 15:18:12,246 - INFO - Epoch 7 Iter 100: loss = 0.0565, memory = 296.3755
2023-05-16 15:18:17,910 - INFO - Epoch 7 Iter 200: loss = 0.0006, memory = 296.3755
2023-05-16 15:18:23,473 - INFO - Epoch 7 Iter 300: loss = 0.0009, memory = 296.3755
2023-05-16 15:18:38,187 - INFO - Epoch 7: validation accuracy = 0.9629
2023-05-16 15:18:47,227 - INFO - Test accuracy = 0.8618
```
