### PR TITLE
[Feature] Add GradScaler for ZeroOptim

### DIFF
--- a/oslo/torch/nn/parallel/data_parallel/grad_scaler/__init__.py
+++ b/oslo/torch/nn/parallel/data_parallel/grad_scaler/__init__.py
@@ -1,0 +1,4 @@
+from .base_grad_scaler import BaseGradScaler
+from .dynamic_grad_scaler import DynamicGradScaler
+
+__ALL__ = ['BaseGradScaler', 'DynamicGradScaler']

--- a/oslo/torch/nn/parallel/data_parallel/grad_scaler/base_grad_scaler.py
+++ b/oslo/torch/nn/parallel/data_parallel/grad_scaler/base_grad_scaler.py
@@ -1,0 +1,82 @@
+from abc import ABC, abstractmethod
+from typing import Dict
+
+import torch
+from torch import Tensor
+
+from oslo.torch.utils.logging import get_dist_logger
+
+__all__ = ['BaseGradScaler']
+
+
+class BaseGradScaler(ABC):
+    """A base class for the gradient scaler.
+
+    Args:
+        initial_scale (float): the initial loss scale
+        verbose (bool): whether to log messages
+    """
+
+    def __init__(self, initial_scale: float, verbose: bool):
+        assert initial_scale > 0
+        self._scale = torch.cuda.FloatTensor([initial_scale])
+        self._verbose = verbose
+
+        if self._verbose:
+            self._logger = get_dist_logger()
+
+    # @property
+    def scale(self, loss) -> Tensor:
+        """Returns the loss scale.
+        """
+
+        return self._scale * loss
+    
+    def step(self, optimizer):
+        self.found_inf = optimizer._check_overflow()
+        return optimizer.step()
+
+    @property
+    def inv_scale(self) -> Tensor:
+        """Returns the inverse of the loss scale.
+        """
+
+        return self._scale.double().reciprocal().float()
+
+    def state_dict(self) -> Dict:
+        """Returns the states of the gradient scaler as a dict object.
+        """
+
+        state_dict = dict()
+        state_dict['scale'] = self.scale
+        return state_dict
+
+    def load_state_dict(self, state_dict: Dict) -> None:
+        """Load the states of the gradient scaler from a dict object.
+
+        Args:
+            state_dict (dict): the states of the gradient scaler
+        """
+
+        self._scale = state_dict['scale']
+
+    @abstractmethod
+    def update(self) -> None:
+        """Update the loss scale.
+
+        Args:
+            overflow (bool): whether overflow occurs
+        """
+        pass
+
+    def log(self, message, *args, **kwargs):
+        """Log messages.
+
+        Args:
+            message (str): the message to log
+            *args: positional arguments for :class:`oslo.torch.utils.logging.DistributedLogger`
+            **kwargs: key-word arguments for :class:`oslo.torch.utils.logging.DistributedLogger`
+        """
+
+        if self._verbose:
+            self._logger.info(message, *args, **kwargs)

--- a/oslo/torch/nn/parallel/data_parallel/grad_scaler/dynamic_grad_scaler.py
+++ b/oslo/torch/nn/parallel/data_parallel/grad_scaler/dynamic_grad_scaler.py
@@ -1,0 +1,118 @@
+from typing import Optional
+
+import torch
+
+from .base_grad_scaler import BaseGradScaler
+
+__all__ = ['DynamicGradScaler']
+
+
+class DynamicGradScaler(BaseGradScaler):
+    """A gradient scaler which uses dynamic loss scale
+
+    Args:
+        initial_scale (float): the initial loss scale, defaults to 2**16
+        growth_factor (float): the multiplication factor for increasing loss scale, defaults to 2
+        backoff_factor (float): the multiplication factor for decreasing loss scale, defaults to 0.5
+        growth_interval (int): the number of steps to increase loss scale when no overflow occurs, defaults to 1000
+        min_scale (float): the minimum loss scale, defaults to None
+        max_scale (float): the maximum loss scale, defaults to None
+        hysteresis (int):  the number of overflows before decreasing loss scale, defaults to 2
+        verbose (bool): whether to log messages, defaults to False
+    """
+
+    def __init__(self,
+                 initial_scale: float = 2**16,
+                 growth_factor: float = 2,
+                 backoff_factor: float = 0.5,
+                 growth_interval: int = 1000,
+                 min_scale: Optional[float] = None,
+                 max_scale: Optional[float] = None,
+                 hysteresis: int = 2,
+                 verbose: bool = False):
+        super().__init__(initial_scale, verbose)
+        if min_scale:
+            self._min_scale = torch.cuda.FloatTensor([min_scale])
+        else:
+            self._min_scale = None
+
+        if max_scale:
+            self._max_scale = torch.cuda.FloatTensor([max_scale])
+        else:
+            self._max_scale = None
+
+        self._growth_factor = growth_factor
+        self._backoff_factor = backoff_factor
+        self._growth_interval = growth_interval
+        self._growth_step = 0
+        self._hysteresis = hysteresis
+        self._hysteresis_step = 0
+        self._sanity_checks()
+
+    def _sanity_checks(self) -> None:
+        """Check if the arguments are correct.
+        """
+
+        if self._min_scale:
+            assert self._min_scale > 0, 'The minimum gradient scale cannot be zero or negative'
+            assert self._min_scale <= self._scale, 'The minimum gradient scale cannot be greater than the current scale'
+        if self._max_scale:
+            assert self._max_scale > 0, 'The maximum gradient scale cannot be zero or negative'
+            assert self._max_scale >= self._scale, 'The maximum gradient scale cannot be smaller than the current scale'
+        assert self._growth_factor > 1, 'The growth factor cannot be equal or smaller than 1'
+        assert 0 < self._backoff_factor < 1, 'The backoff factor must be between 0 and 1'
+        assert self._hysteresis >= 0, 'The hysteresis cannot be negative'
+
+    def update(self) -> None:
+        """Update the loss scale.
+
+        Args:
+            overflow (bool): whether overflow occurs
+        """
+        if self.found_inf:
+            self._hysteresis_step += 1
+            self._growth_step = 0
+
+            if self._hysteresis_step >= self._hysteresis:
+                self._backoff_scale()
+                self.log(f"Overflow occurs, the loss scale is adjusted to {self.scale.item()}", ranks=[0])
+        else:
+            self._growth_step += 1
+            if self._growth_step == self._growth_interval:
+                self._growth_step = 0
+                self._hysteresis_step = 0
+                self._grow_scale()
+                self.log(
+                    f"No overflow for consecutive {self._growth_interval} steps, "
+                    f"the loss scale is adjusted to {self.scale.item()}",
+                    ranks=[0])
+
+    def _backoff_scale(self) -> None:
+        """Decrease the loss scale
+        """
+
+        self._scale = self._scale * self._backoff_factor
+        if self._min_scale:
+            self._scale = torch.max(self._scale, self._min_scale)
+
+    def _grow_scale(self) -> None:
+        """Increase the loss scale
+        """
+
+        self._scale = self._scale * self._growth_factor
+        if self._max_scale:
+            self._scale = torch.min(self._scale, self._max_scale)
+
+    def state_dict(self):
+        state_dict = dict()
+        state_dict['scale'] = self._scale
+        state_dict['growth_factor'] = self._growth_factor
+        state_dict['backoff_factor'] = self._backoff_factor
+        state_dict['hysteresis'] = self._hysteresis
+        return state_dict
+
+    def load_state_dict(self, state_dict):
+        self._scale = state_dict['scale'].cuda(torch.cuda.current_device())
+        self._growth_factor = state_dict['growth_factor']
+        self._backoff_factor = state_dict['backoff_factor']
+        self._hysteresis = state_dict['hysteresis']


### PR DESCRIPTION
## Add GradScaler for ZeroOptim

-

## Description

Test Script
```python
import os

import torch, time, gc
import torch.multiprocessing as mp
import torch.distributed as dist
from torch.nn.parallel import DistributedDataParallel as DDP

from oslo.torch.utils import get_free_port, set_seed
from oslo.torch.distributed.parallel_context import ParallelContext
from oslo.torch.nn.parallel.data_parallel.zero import ZeroRedundancyOptimizer as OsloZeroRedundancyOptimizer
from oslo.torch.nn.parallel.data_parallel.grad_scaler import DynamicGradScaler
from torch.distributed.optim import ZeroRedundancyOptimizer

def setup(rank, world_size):
    os.environ["MASTER_ADDR"] = "localhost"
    os.environ["MASTER_PORT"] = "12345"
    os.environ["RANK"] = str(rank)
    os.environ["LOCAL_RANK"] = str(rank)
    os.environ["WORLD_SIZE"] = str(world_size)
    os.environ["LOCAL_WORLD_SIZE"] = str(world_size)

def cleanup():
    dist.destroy_process_group()

def main_print(args):
    if dist.get_rank() != 0:
        return
    print(args)

# Timing utilities
start_time = None

def start_timer():
    global start_time
    gc.collect()
    torch.cuda.empty_cache()
    torch.cuda.reset_max_memory_allocated()
    torch.cuda.synchronize()
    start_time = time.time()


def end_timer_and_print(local_msg):
    torch.cuda.synchronize()
    end_time = time.time()
    if dist.get_rank() != 0:
        return
    print("\n" + local_msg)
    print("Total execution time = {:.3f} sec".format(end_time - start_time))
    print("Max memory used by tensors = {} bytes".format(torch.cuda.max_memory_allocated()))

def make_model(in_size, out_size, num_layers):
    layers = []
    for _ in range(num_layers - 1):
        layers.append(torch.nn.Linear(in_size, in_size))
        layers.append(torch.nn.ReLU())
    layers.append(torch.nn.Linear(in_size, out_size))
    return torch.nn.Sequential(*tuple(layers))

def train(rank, world_size):
    print(f"Running oslo DDP example on rank {rank}.")
    setup(rank, world_size)
    parallel_context = ParallelContext.from_torch(data_parallel_size=world_size)

    batch_size = 512 # Try, for example, 128, 256, 513.
    in_size = 4096
    out_size = 4096
    num_layers = 3
    num_batches = 1
    epochs = 1
    use_zero = True
    use_oslo = True
    if use_oslo:
        use_zero = False

    local_rank = torch.distributed.get_rank()

    # Creates data in default precision.
    # The same data is used for both default and mixed precision trials below.
    # You don't need to manually change inputs' ``dtype`` when enabling mixed precision.
    set_seed(2021 + local_rank)
    data = [torch.randn(batch_size, in_size, device="cuda") for _ in range(num_batches)]
    targets = [torch.randn(batch_size, out_size, device="cuda") for _ in range(num_batches)]


    net = make_model(in_size, out_size, num_layers).to(rank)
    model = DDP(net, device_ids=[rank])
    loss_fn = torch.nn.MSELoss()
    if use_zero:
        opt = ZeroRedundancyOptimizer(
            model.parameters(),
            optimizer_class=torch.optim.Adam,
            lr=0.01
        )
    elif use_oslo:
        opt = OsloZeroRedundancyOptimizer(
            torch.optim.Adam(model.parameters(), lr=0.01),
            parallel_context=parallel_context,
            overlap_communication=True,
        )
    else:
        opt = torch.optim.Adam(model.parameters(), lr=0.01)

    # start_timer()
    # for epoch in range(epochs):
    #     for input, target in zip(data, targets):
    #         output = net(input)
    #         loss = loss_fn(output, target)
    #         loss.backward()
    #         opt.step()
    #         opt.zero_grad() # set_to_none=True here can modestly improve performance
    # end_timer_and_print("Default precision:")

    # start_timer()
    # for epoch in range(epochs):
    #     for input, target in zip(data, targets):
    #         with torch.autocast(device_type='cuda', dtype=torch.float16):
    #             output = net(input)
    #             assert output.dtype is torch.float16
    #             loss = loss_fn(output, target)
    #             assert loss.dtype is torch.float32

    #         loss.backward()
    #         opt.step()
    #         opt.zero_grad() # set_to_none=True here can modestly improve performance
    # end_timer_and_print("Default precision:")

    if use_oslo:
        scaler = DynamicGradScaler()
    else:
        scaler = torch.cuda.amp.GradScaler()
    start_timer()
    for epoch in range(epochs):
        for input, target in zip(data, targets):
            with torch.autocast(device_type='cuda', dtype=torch.float16):
                output = net(input)
                assert output.dtype is torch.float16
                loss = loss_fn(output, target)
                assert loss.dtype is torch.float32

            scaler.scale(loss).backward()
            scaler.step(opt)
            scaler.update()
            opt.zero_grad() # set_to_none=True here can modestly improve performance
    end_timer_and_print("Default precision:")


def main(world_size):
    mp.spawn(train, args=(world_size,), nprocs=world_size, join=True)


if __name__ == "__main__":
    main(2)
```