### PR TITLE
Add requirement for lightseq2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ parameterized >= 0.8.1
 psutil
 py-cpuinfo
 pybind11
+scipy
 torch >= 1.11.0
 transformers


### PR DESCRIPTION
## Title

- import error if scipy is not installed

## Description

-

## Linked Issues

- resolved #00
